### PR TITLE
Windows build support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,17 +12,17 @@ pub fn build(b: *std.Build) void {
     const module = b.addModule("opencl", .{
         .root_source_file = b.path("src/opencl.zig"),
         .target = target,
-        .optimize = optimize
+        .optimize = optimize,
     });
-    module.addIncludePath(.{
-        .cwd_relative = "/usr/include/"
-    });
-    module.linkSystemLibrary("OpenCL", .{
-        .needed = true
-    });
-    module.linkSystemLibrary("c", .{
-        .needed = true
-    });
+    const headers = b.dependency("opencl_headers", .{});
+    module.addIncludePath(headers.path(""));
+    if (target.result.os.tag == .windows) {
+        module.addLibraryPath(.{ .cwd_relative = "C:\\Windows\\System32\\" });
+    } else {
+        module.addIncludePath(.{ .cwd_relative = "/usr/include/" });
+    }
+    module.linkSystemLibrary("OpenCL", .{ .needed = true });
+    module.linkSystemLibrary("c", .{ .needed = true });
     module.addOptions("opencl_config", options);
 
     const exe_unit_tests = b.addTest(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,13 @@
     .minimum_zig_version = "0.14.0",
     .fingerprint = 0x46243d52c361e5cf,
 
+    .dependencies = .{
+        .opencl_headers = .{
+            .url = "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2024.10.24.tar.gz",
+            .hash = "1220b550e9e79baf05f8b4797bfbc392a49856d08de65d05fd2082298d17ad0ddd4d",
+        },
+    },
     .paths = .{
         "",
-    }
+    },
 }


### PR DESCRIPTION
Makes it possible to build on windows. In addition, adds the header files as a dependancy, which in my opinion makes it more portable (otherwise finding them on windows system is impossible).

